### PR TITLE
Es/add internationlization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ web-build/
 
 # Temporary files created by Metro to check the health of the file watcher
 .metro-health-check*
+
+/translations

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx pretty-quick --staged
+npm run extract-messages

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,3 @@
+files:
+  - source: /messages/en.json
+    translation: /messages/%two_letters_code%.json

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,6 @@
 {
   "app.firstMessage": {
-    "defaultMessage": "This is a test",
-    "description": "Used as a tester"
+    "description": "Used as a tester",
+    "message": "This is a test"
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,6 @@
+{
+  "app.firstMessage": {
+    "defaultMessage": "This is a test",
+    "description": "Used as a tester"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,9 @@
         "@babel/core": "^7.20.0",
         "@formatjs/cli": "^6.0.4",
         "@types/react": "~18.0.14",
+        "glob": "^9.3.0",
         "husky": "^8.0.0",
+        "mkdirp": "^2.1.5",
         "prettier": "^2.8.4",
         "pretty-quick": "^3.1.3",
         "typescript": "^4.9.4"
@@ -2003,6 +2005,25 @@
         "xml2js": "0.4.23"
       }
     },
+    "node_modules/@expo/config-plugins/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@expo/config-plugins/node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -2021,6 +2042,25 @@
       "version": "48.0.0",
       "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-48.0.0.tgz",
       "integrity": "sha512-DwyV4jTy/+cLzXGAo1xftS6mVlSiLIWZjl9DjTCLPFVgNYQxnh7htPilRv4rBhiNs7KaznWqKU70+4zQoKVT9A=="
+    },
+    "node_modules/@expo/config/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@expo/config/node_modules/semver": {
       "version": "7.3.2",
@@ -2107,6 +2147,36 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@expo/devcert/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/devcert/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/@expo/devcert/node_modules/rimraf": {
@@ -2797,6 +2867,25 @@
         "node": ">=10"
       }
     },
+    "node_modules/@npmcli/move-file/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@npmcli/move-file/node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -2844,6 +2933,25 @@
         "deepmerge": "^3.2.0",
         "glob": "^7.1.3",
         "joi": "^17.2.1"
+      }
+    },
+    "node_modules/@react-native-community/cli-config/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@react-native-community/cli-debugger-ui": {
@@ -2899,6 +3007,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli-doctor/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@react-native-community/cli-doctor/node_modules/log-symbols": {
@@ -3012,6 +3139,25 @@
         "logkitty": "^0.7.1"
       }
     },
+    "node_modules/@react-native-community/cli-hermes/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@react-native-community/cli-platform-android": {
       "version": "10.1.3",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-10.1.3.tgz",
@@ -3022,6 +3168,25 @@
         "execa": "^1.0.0",
         "glob": "^7.1.3",
         "logkitty": "^0.7.1"
+      }
+    },
+    "node_modules/@react-native-community/cli-platform-android/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@react-native-community/cli-platform-ios": {
@@ -3045,6 +3210,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-community/cli-platform-ios/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@react-native-community/cli-platform-ios/node_modules/log-symbols": {
@@ -3881,6 +4065,25 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/babel-plugin-module-resolver/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/babel-plugin-module-resolver/node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -4311,6 +4514,25 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/cacache/node_modules/mkdirp": {
@@ -5102,6 +5324,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/del/node_modules/is-extglob": {
@@ -6046,19 +6287,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.0.tgz",
+      "integrity": "sha512-EAZejC7JvnQINayvB/7BJbpZpNOJ8Lrw2OZNEvQxe0vaLn1SuwMcfV7/MNaX8L/T0wmptBFI4YMtDvSBxYDc7w==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^7.4.1",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6092,6 +6332,39 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.2.tgz",
+      "integrity": "sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/minipass": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
+      "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/globals": {
@@ -7221,6 +7494,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jscodeshift/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/jscodeshift/node_modules/is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -7706,6 +7998,25 @@
       "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.73.8.tgz",
       "integrity": "sha512-VzFGu4kJGIkLjyDgVoM2ZxIHlMdCZWMqVIux9N+EeyMVMvGXTiXW8eGROgxzDhVjyR58IjfMsYpRCKz5dR+2ew=="
     },
+    "node_modules/metro-cache/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/metro-cache/node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -8175,6 +8486,25 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/metro/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/metro/node_modules/metro-react-native-babel-preset": {
       "version": "0.73.8",
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.8.tgz",
@@ -8495,14 +8825,18 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.5.tgz",
+      "integrity": "sha512-jbjfql+shJtAPrFoKxHOXip4xS+kul9W3OzfzzrqueWK2QMGon2bFH2opl6W9EagBThjEz+iysyi/swOoVfB/w==",
+      "dev": true,
       "bin": {
-        "mkdirp": "bin/cmd.js"
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mri": {
@@ -8547,6 +8881,18 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/mv/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "optional": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mz": {
@@ -9048,6 +9394,40 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-scurry": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.1.tgz",
+      "integrity": "sha512-OW+5s+7cw6253Q4E+8qQ/u1fVvcJQCJo/VFD8pje+dbJCF1n5ZRMV2AEHbGp+5Q7jxQIYJxkHopnj6nzdGeZLA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^7.14.1",
+        "minipass": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
+      "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -9956,6 +10336,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/react-native/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/react-native/node_modules/p-limit": {
@@ -11001,6 +11392,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sucrase/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/sudo-prompt": {
@@ -13405,6 +13815,19 @@
         "sucrase": "^3.20.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -13434,6 +13857,19 @@
         "xml2js": "0.4.23"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "semver": {
           "version": "7.3.8",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -13516,6 +13952,27 @@
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "requires": {
+            "minimist": "^1.2.6"
           }
         },
         "rimraf": {
@@ -14094,6 +14551,19 @@
         "rimraf": "^3.0.2"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -14131,6 +14601,21 @@
         "deepmerge": "^3.2.0",
         "glob": "^7.1.3",
         "joi": "^17.2.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "@react-native-community/cli-debugger-ui": {
@@ -14183,6 +14668,19 @@
           "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
           "requires": {
             "restore-cursor": "^3.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "log-symbols": {
@@ -14272,6 +14770,19 @@
             "glob": "^7.1.3",
             "logkitty": "^0.7.1"
           }
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         }
       }
     },
@@ -14285,6 +14796,21 @@
         "execa": "^1.0.0",
         "glob": "^7.1.3",
         "logkitty": "^0.7.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "@react-native-community/cli-platform-ios": {
@@ -14305,6 +14831,19 @@
           "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
           "requires": {
             "restore-cursor": "^3.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "log-symbols": {
@@ -14980,6 +15519,19 @@
         "resolve": "^1.13.1"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "resolve": {
           "version": "1.22.1",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -15319,6 +15871,19 @@
         "unique-filename": "^1.1.1"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -15908,6 +16473,19 @@
         "slash": "^3.0.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "is-extglob": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -16645,16 +17223,41 @@
       "integrity": "sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg=="
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.0.tgz",
+      "integrity": "sha512-EAZejC7JvnQINayvB/7BJbpZpNOJ8Lrw2OZNEvQxe0vaLn1SuwMcfV7/MNaX8L/T0wmptBFI4YMtDvSBxYDc7w==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^7.4.1",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.2.tgz",
+          "integrity": "sha512-xy4q7wou3vUoC9k1xGTXc+awNdGaGVHtFUaey8tiX4H1QRc04DZ/rmDFwNm2EBsuYEhAZ6SgMmYf3InGY6OauA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
+          "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+          "dev": true
+        }
       }
     },
     "glob-parent": {
@@ -17541,6 +18144,19 @@
             }
           }
         },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -17918,6 +18534,19 @@
             "ms": "2.0.0"
           }
         },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "metro-react-native-babel-preset": {
           "version": "0.73.8",
           "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.8.tgz",
@@ -18092,6 +18721,19 @@
         "rimraf": "^3.0.2"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -18595,12 +19237,10 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "requires": {
-        "minimist": "^1.2.6"
-      }
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.5.tgz",
+      "integrity": "sha512-jbjfql+shJtAPrFoKxHOXip4xS+kul9W3OzfzzrqueWK2QMGon2bFH2opl6W9EagBThjEz+iysyi/swOoVfB/w==",
+      "dev": true
     },
     "mri": {
       "version": "1.2.0",
@@ -18635,6 +19275,17 @@
         "mkdirp": "~0.5.1",
         "ncp": "~2.0.0",
         "rimraf": "~2.4.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "optional": true,
+          "requires": {
+            "minimist": "^1.2.6"
+          }
+        }
       }
     },
     "mz": {
@@ -19004,6 +19655,30 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "path-scurry": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.6.1.tgz",
+      "integrity": "sha512-OW+5s+7cw6253Q4E+8qQ/u1fVvcJQCJo/VFD8pje+dbJCF1n5ZRMV2AEHbGp+5Q7jxQIYJxkHopnj6nzdGeZLA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^7.14.1",
+        "minipass": "^4.0.2"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+          "dev": true
+        },
+        "minipass": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.5.tgz",
+          "integrity": "sha512-+yQl7SX3bIT83Lhb4BVorMAHVuqsskxRdlmO9kTpyukp8vsm2Sn/fUOV9xlnG8/a5JsypJzap21lz/y3FBMJ8Q==",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -19636,6 +20311,14 @@
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "requires": {
             "p-locate": "^4.1.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "requires": {
+            "minimist": "^1.2.6"
           }
         },
         "p-limit": {
@@ -20472,6 +21155,21 @@
         "mz": "^2.7.0",
         "pirates": "^4.0.1",
         "ts-interface-checker": "^0.1.9"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "sudo-prompt": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,25 +8,16 @@
       "name": "mapeo-mobile-shell",
       "version": "1.0.0",
       "dependencies": {
-        "@react-navigation/drawer": "^6.6.2",
-        "@react-navigation/native": "^6.1.6",
-        "@react-navigation/native-stack": "^6.9.12",
         "expo": "~48.0.6",
         "expo-status-bar": "~1.4.4",
-        "react": "18.2.0",
-        "react-intl": "^6.2.10",
-        "react-native": "0.71.3",
-        "react-native-gesture-handler": "~2.9.0",
-        "react-native-reanimated": "~2.14.4",
-        "react-native-safe-area-context": "^4.5.0",
-        "react-native-screens": "^3.20.0",
-        "react-native-vector-icons": "^9.2.0"
+        "react": "^18.2.0",
+        "react-intl": "^6.3.0",
+        "react-native": "0.71.3"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
+        "@formatjs/cli": "^6.0.4",
         "@types/react": "~18.0.14",
-        "@types/react-native": "^0.71.3",
-        "@types/react-native-vector-icons": "^6.4.13",
         "husky": "^8.0.0",
         "prettier": "^2.8.4",
         "pretty-quick": "^3.1.3",
@@ -1366,20 +1357,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-object-assign": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.18.6.tgz",
-      "integrity": "sha512-mQisZ3JfqWh2gVXvfqYCAAyRs6+7oev+myBsTwW5RnPhYXOTuCEw2oe3YgxlXMViXUS53lG8koulI7mJ+8JE+A==",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-object-super": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz",
@@ -1882,17 +1859,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@egjs/hammerjs": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
-      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
-      "dependencies": {
-        "@types/hammerjs": "^2.0.36"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/@expo/bunyan": {
@@ -2422,6 +2388,26 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@formatjs/cli": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli/-/cli-6.0.4.tgz",
+      "integrity": "sha512-ivb+uUcYmHnffBkXM7OM4NDofxyfnVvW5G52p+M9Cg3DGMz3wVBm3TwW3SXgGGTft7CMWHeGQGXjxTOwBYKeEA==",
+      "dev": true,
+      "bin": {
+        "formatjs": "bin/formatjs"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "^3.2.34"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
@@ -3445,118 +3431,6 @@
       "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
       "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ=="
     },
-    "node_modules/@react-navigation/core": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-6.4.8.tgz",
-      "integrity": "sha512-klZ9Mcf/P2j+5cHMoGyIeurEzyBM2Uq9+NoSFrF6sdV5iCWHLFhrCXuhbBiQ5wVLCKf4lavlkd/DDs47PXs9RQ==",
-      "dependencies": {
-        "@react-navigation/routers": "^6.1.8",
-        "escape-string-regexp": "^4.0.0",
-        "nanoid": "^3.1.23",
-        "query-string": "^7.1.3",
-        "react-is": "^16.13.0",
-        "use-latest-callback": "^0.1.5"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@react-navigation/core/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@react-navigation/core/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/@react-navigation/drawer": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-6.6.2.tgz",
-      "integrity": "sha512-6qt4guBdz7bkdo/8BLSCcFNdQdSPYyNn05D9cD+VCY3mGThSiD8bRiP9ju+64im7LsSU+bNWXaP8RxA/FtTVQg==",
-      "dependencies": {
-        "@react-navigation/elements": "^1.3.17",
-        "color": "^4.2.3",
-        "warn-once": "^0.1.0"
-      },
-      "peerDependencies": {
-        "@react-navigation/native": "^6.0.0",
-        "react": "*",
-        "react-native": "*",
-        "react-native-gesture-handler": ">= 1.0.0",
-        "react-native-reanimated": ">= 1.0.0",
-        "react-native-safe-area-context": ">= 3.0.0",
-        "react-native-screens": ">= 3.0.0"
-      }
-    },
-    "node_modules/@react-navigation/elements": {
-      "version": "1.3.17",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.17.tgz",
-      "integrity": "sha512-sui8AzHm6TxeEvWT/NEXlz3egYvCUog4tlXA4Xlb2Vxvy3purVXDq/XsM56lJl344U5Aj/jDzkVanOTMWyk4UA==",
-      "peerDependencies": {
-        "@react-navigation/native": "^6.0.0",
-        "react": "*",
-        "react-native": "*",
-        "react-native-safe-area-context": ">= 3.0.0"
-      }
-    },
-    "node_modules/@react-navigation/native": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-6.1.6.tgz",
-      "integrity": "sha512-14PmSy4JR8HHEk04QkxQ0ZLuqtiQfb4BV9kkMXD2/jI4TZ+yc43OnO6fQ2o9wm+Bq8pY3DxyerC2AjNUz+oH7Q==",
-      "dependencies": {
-        "@react-navigation/core": "^6.4.8",
-        "escape-string-regexp": "^4.0.0",
-        "fast-deep-equal": "^3.1.3",
-        "nanoid": "^3.1.23"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/@react-navigation/native-stack": {
-      "version": "6.9.12",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-6.9.12.tgz",
-      "integrity": "sha512-kS2zXCWP0Rgt7uWaCUKrRl7U2U1Gp19rM1kyRY2YzBPXhWGVPjQ2ygBp88CTQzjgy8M07H/79jvGiZ0mlEJI+g==",
-      "dependencies": {
-        "@react-navigation/elements": "^1.3.17",
-        "warn-once": "^0.1.0"
-      },
-      "peerDependencies": {
-        "@react-navigation/native": "^6.0.0",
-        "react": "*",
-        "react-native": "*",
-        "react-native-safe-area-context": ">= 3.0.0",
-        "react-native-screens": ">= 3.0.0"
-      }
-    },
-    "node_modules/@react-navigation/native/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@react-navigation/routers": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-6.1.8.tgz",
-      "integrity": "sha512-CEge+ZLhb1HBrSvv4RwOol7EKLW1QoqVIQlE9TN5MpxS/+VoQvP+cLbuz0Op53/iJfYhtXRFd1ZAd3RTRqto9w==",
-      "dependencies": {
-        "nanoid": "^3.1.23"
-      }
-    },
     "node_modules/@segment/loosely-validate-event": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -3604,11 +3478,6 @@
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
       }
-    },
-    "node_modules/@types/hammerjs": {
-      "version": "2.0.41",
-      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
-      "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA=="
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -3664,34 +3533,6 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-native": {
-      "version": "0.71.3",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.71.3.tgz",
-      "integrity": "sha512-0Uqw1YZ0qbVla0MMWFTANFm6W8KYWNvGQmYfucdecbXivLMcQ2v4PovuYFKr7bE6Bc5nDCUEaga962Y8gcDF7A==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-native-vector-icons": {
-      "version": "6.4.13",
-      "resolved": "https://registry.npmjs.org/@types/react-native-vector-icons/-/react-native-vector-icons-6.4.13.tgz",
-      "integrity": "sha512-1PqFoKuXTSzMHwGMAr+REdYJBQAbe9xrww3ecZR0FsHcD1K+vGS/rxuAriL4rsI6+p69sZQjDzpEVAbDQcjSwA==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "*",
-        "@types/react-native": "^0.70"
-      }
-    },
-    "node_modules/@types/react-native-vector-icons/node_modules/@types/react-native": {
-      "version": "0.70.11",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.70.11.tgz",
-      "integrity": "sha512-FobPtzoNPNHugBKMfzs4Li0Q9ei4tgU8SI1M5Ayg7+t5/+noCm2sknI8uwij22wMkcHcefv8RFx4q28nNVJtCQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/scheduler": {
@@ -4827,18 +4668,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -4851,31 +4680,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/color/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colorette": {
       "version": "1.4.0",
@@ -5851,11 +5655,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
     "node_modules/fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -5943,14 +5742,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -7636,11 +7427,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
-    },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -8771,17 +8557,6 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
-      }
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/nanomatch": {
@@ -9925,23 +9700,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/query-string": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
-      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
-      "dependencies": {
-        "decode-uri-component": "^0.2.2",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -10042,21 +9800,10 @@
         }
       }
     },
-    "node_modules/react-freeze": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.3.tgz",
-      "integrity": "sha512-ZnXwLQnGzrDpHBHiC56TXFXvmolPeMjTn1UOm610M4EXGzbEDR7oOIyS2ZiItgbs6eZc4oU/a0hpk8PrcKvv5g==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0"
-      }
-    },
     "node_modules/react-intl": {
-      "version": "6.2.10",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.2.10.tgz",
-      "integrity": "sha512-l2TpskkFR0OzQnq7ChiJ5ZX23USZSzpKOcaR9MYC4UOHE9bT4kQ5JXXolgkq3tiOlvseEOzUCerlzn886AX9Yg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.3.0.tgz",
+      "integrity": "sha512-3hNuLecjy2IwAYbkeI2CRi5RyFN/ucBvHBnmDdePaJt/sTGa1aw2s+0QaW/reL9uTKP/O84O23wO3qZxx3FonQ==",
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.14.3",
         "@formatjs/icu-messageformat-parser": "2.3.0",
@@ -10145,134 +9892,10 @@
         "nullthrows": "^1.1.1"
       }
     },
-    "node_modules/react-native-gesture-handler": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.9.0.tgz",
-      "integrity": "sha512-a0BcH3Qb1tgVqUutc6d3VuWQkI1AM3+fJx8dkxzZs9t06qA27QgURYFoklpabuWpsUTzuKRpxleykp25E8m7tg==",
-      "dependencies": {
-        "@egjs/hammerjs": "^2.0.17",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-gradle-plugin": {
       "version": "0.71.16",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.16.tgz",
       "integrity": "sha512-H2BjG2zk7B7Wii9sXvd9qhCVRQYDAHSWdMw9tscmZBqSP62DkIWEQSk4/B2GhQ4aK9ydVXgtqR6tBeg3yy8TSA=="
-    },
-    "node_modules/react-native-reanimated": {
-      "version": "2.14.4",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.14.4.tgz",
-      "integrity": "sha512-DquSbl7P8j4SAmc+kRdd75Ianm8G+IYQ9T4AQ6lrpLVeDkhZmjWI0wkutKWnp6L7c5XNVUrFDUf69dwETLCItQ==",
-      "dependencies": {
-        "@babel/plugin-transform-object-assign": "^7.16.7",
-        "@babel/preset-typescript": "^7.16.7",
-        "convert-source-map": "^1.7.0",
-        "invariant": "^2.2.4",
-        "lodash.isequal": "^4.5.0",
-        "setimmediate": "^1.0.5",
-        "string-hash-64": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-safe-area-context": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz",
-      "integrity": "sha512-0WORnk9SkREGUg2V7jHZbuN5x4vcxj/1B0QOcXJjdYWrzZHgLcUzYWWIUecUPJh747Mwjt/42RZDOaFn3L8kPQ==",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-screens": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.20.0.tgz",
-      "integrity": "sha512-joWUKWAVHxymP3mL9gYApFHAsbd9L6ZcmpoZa6Sl3W/82bvvNVMqcfP7MeNqVCg73qZ8yL4fW+J/syusHleUgg==",
-      "dependencies": {
-        "react-freeze": "^1.0.0",
-        "warn-once": "^0.1.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-vector-icons": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.2.0.tgz",
-      "integrity": "sha512-wKYLaFuQST/chH3AJRjmOLoLy3JEs1JR6zMNgTaemFpNoXs0ztRnTxcxFD9xhX7cJe1/zoN5BpQYe7kL0m5yyA==",
-      "dependencies": {
-        "prop-types": "^15.7.2",
-        "yargs": "^16.1.1"
-      },
-      "bin": {
-        "fa5-upgrade": "bin/fa5-upgrade.sh",
-        "generate-icon": "bin/generate-icon.js"
-      }
-    },
-    "node_modules/react-native-vector-icons/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/react-native-vector-icons/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-native-vector-icons/node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/react-native-vector-icons/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/react-native-vector-icons/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/react-native/node_modules/@react-native-community/cli": {
       "version": "10.1.3",
@@ -10926,19 +10549,6 @@
         "node": ">= 5.10.0"
       }
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -11178,14 +10788,6 @@
         "node": "*"
       }
     },
-    "node_modules/split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -11295,14 +10897,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -11310,11 +10904,6 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
-    },
-    "node_modules/string-hash-64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string-hash-64/-/string-hash-64-1.0.3.tgz",
-      "integrity": "sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw=="
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -12109,11 +11698,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/use-latest-callback": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.1.5.tgz",
-      "integrity": "sha512-HtHatS2U4/h32NlkhupDsPlrbiD27gSH5swBdtXbCAlc6pfOFzaj0FehW/FO12rx8j2Vy4/lJScCiJyM01E+bQ=="
-    },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -12177,11 +11761,6 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
-    },
-    "node_modules/warn-once": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
-      "integrity": "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q=="
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
@@ -13360,14 +12939,6 @@
         "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
-    "@babel/plugin-transform-object-assign": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.18.6.tgz",
-      "integrity": "sha512-mQisZ3JfqWh2gVXvfqYCAAyRs6+7oev+myBsTwW5RnPhYXOTuCEw2oe3YgxlXMViXUS53lG8koulI7mJ+8JE+A==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.18.6"
-      }
-    },
     "@babel/plugin-transform-object-super": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz",
@@ -13721,14 +13292,6 @@
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
-      }
-    },
-    "@egjs/hammerjs": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
-      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
-      "requires": {
-        "@types/hammerjs": "^2.0.36"
       }
     },
     "@expo/bunyan": {
@@ -14193,6 +13756,13 @@
           }
         }
       }
+    },
+    "@formatjs/cli": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli/-/cli-6.0.4.tgz",
+      "integrity": "sha512-ivb+uUcYmHnffBkXM7OM4NDofxyfnVvW5G52p+M9Cg3DGMz3wVBm3TwW3SXgGGTft7CMWHeGQGXjxTOwBYKeEA==",
+      "dev": true,
+      "requires": {}
     },
     "@formatjs/ecma402-abstract": {
       "version": "1.14.3",
@@ -15043,82 +14613,6 @@
       "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
       "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ=="
     },
-    "@react-navigation/core": {
-      "version": "6.4.8",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-6.4.8.tgz",
-      "integrity": "sha512-klZ9Mcf/P2j+5cHMoGyIeurEzyBM2Uq9+NoSFrF6sdV5iCWHLFhrCXuhbBiQ5wVLCKf4lavlkd/DDs47PXs9RQ==",
-      "requires": {
-        "@react-navigation/routers": "^6.1.8",
-        "escape-string-regexp": "^4.0.0",
-        "nanoid": "^3.1.23",
-        "query-string": "^7.1.3",
-        "react-is": "^16.13.0",
-        "use-latest-callback": "^0.1.5"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
-      }
-    },
-    "@react-navigation/drawer": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-6.6.2.tgz",
-      "integrity": "sha512-6qt4guBdz7bkdo/8BLSCcFNdQdSPYyNn05D9cD+VCY3mGThSiD8bRiP9ju+64im7LsSU+bNWXaP8RxA/FtTVQg==",
-      "requires": {
-        "@react-navigation/elements": "^1.3.17",
-        "color": "^4.2.3",
-        "warn-once": "^0.1.0"
-      }
-    },
-    "@react-navigation/elements": {
-      "version": "1.3.17",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.17.tgz",
-      "integrity": "sha512-sui8AzHm6TxeEvWT/NEXlz3egYvCUog4tlXA4Xlb2Vxvy3purVXDq/XsM56lJl344U5Aj/jDzkVanOTMWyk4UA==",
-      "requires": {}
-    },
-    "@react-navigation/native": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-6.1.6.tgz",
-      "integrity": "sha512-14PmSy4JR8HHEk04QkxQ0ZLuqtiQfb4BV9kkMXD2/jI4TZ+yc43OnO6fQ2o9wm+Bq8pY3DxyerC2AjNUz+oH7Q==",
-      "requires": {
-        "@react-navigation/core": "^6.4.8",
-        "escape-string-regexp": "^4.0.0",
-        "fast-deep-equal": "^3.1.3",
-        "nanoid": "^3.1.23"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        }
-      }
-    },
-    "@react-navigation/native-stack": {
-      "version": "6.9.12",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-6.9.12.tgz",
-      "integrity": "sha512-kS2zXCWP0Rgt7uWaCUKrRl7U2U1Gp19rM1kyRY2YzBPXhWGVPjQ2ygBp88CTQzjgy8M07H/79jvGiZ0mlEJI+g==",
-      "requires": {
-        "@react-navigation/elements": "^1.3.17",
-        "warn-once": "^0.1.0"
-      }
-    },
-    "@react-navigation/routers": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-6.1.8.tgz",
-      "integrity": "sha512-CEge+ZLhb1HBrSvv4RwOol7EKLW1QoqVIQlE9TN5MpxS/+VoQvP+cLbuz0Op53/iJfYhtXRFd1ZAd3RTRqto9w==",
-      "requires": {
-        "nanoid": "^3.1.23"
-      }
-    },
     "@segment/loosely-validate-event": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -15166,11 +14660,6 @@
       "requires": {
         "@sinonjs/commons": "^2.0.0"
       }
-    },
-    "@types/hammerjs": {
-      "version": "2.0.41",
-      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
-      "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA=="
     },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -15226,36 +14715,6 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "@types/react-native": {
-      "version": "0.71.3",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.71.3.tgz",
-      "integrity": "sha512-0Uqw1YZ0qbVla0MMWFTANFm6W8KYWNvGQmYfucdecbXivLMcQ2v4PovuYFKr7bE6Bc5nDCUEaga962Y8gcDF7A==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
-    "@types/react-native-vector-icons": {
-      "version": "6.4.13",
-      "resolved": "https://registry.npmjs.org/@types/react-native-vector-icons/-/react-native-vector-icons-6.4.13.tgz",
-      "integrity": "sha512-1PqFoKuXTSzMHwGMAr+REdYJBQAbe9xrww3ecZR0FsHcD1K+vGS/rxuAriL4rsI6+p69sZQjDzpEVAbDQcjSwA==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*",
-        "@types/react-native": "^0.70"
-      },
-      "dependencies": {
-        "@types/react-native": {
-          "version": "0.70.11",
-          "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.70.11.tgz",
-          "integrity": "sha512-FobPtzoNPNHugBKMfzs4Li0Q9ei4tgU8SI1M5Ayg7+t5/+noCm2sknI8uwij22wMkcHcefv8RFx4q28nNVJtCQ==",
-          "dev": true,
-          "requires": {
-            "@types/react": "*"
-          }
-        }
       }
     },
     "@types/scheduler": {
@@ -16105,30 +15564,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "requires": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        }
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -16141,15 +15576,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "colorette": {
       "version": "1.4.0",
@@ -16917,11 +16343,6 @@
         }
       }
     },
-    "fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
     "fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -16997,11 +16418,6 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
-    },
-    "filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -18286,11 +17702,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
-    },
     "lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -19236,11 +18647,6 @@
         "thenify-all": "^1.0.0"
       }
     },
-    "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -20061,17 +19467,6 @@
         "side-channel": "^1.0.4"
       }
     },
-    "query-string": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
-      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
-      "requires": {
-        "decode-uri-component": "^0.2.2",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
-    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -20134,16 +19529,10 @@
         }
       }
     },
-    "react-freeze": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.3.tgz",
-      "integrity": "sha512-ZnXwLQnGzrDpHBHiC56TXFXvmolPeMjTn1UOm610M4EXGzbEDR7oOIyS2ZiItgbs6eZc4oU/a0hpk8PrcKvv5g==",
-      "requires": {}
-    },
     "react-intl": {
-      "version": "6.2.10",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.2.10.tgz",
-      "integrity": "sha512-l2TpskkFR0OzQnq7ChiJ5ZX23USZSzpKOcaR9MYC4UOHE9bT4kQ5JXXolgkq3tiOlvseEOzUCerlzn886AX9Yg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.3.0.tgz",
+      "integrity": "sha512-3hNuLecjy2IwAYbkeI2CRi5RyFN/ucBvHBnmDdePaJt/sTGa1aw2s+0QaW/reL9uTKP/O84O23wO3qZxx3FonQ==",
       "requires": {
         "@formatjs/ecma402-abstract": "1.14.3",
         "@formatjs/icu-messageformat-parser": "2.3.0",
@@ -20286,104 +19675,10 @@
         "nullthrows": "^1.1.1"
       }
     },
-    "react-native-gesture-handler": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.9.0.tgz",
-      "integrity": "sha512-a0BcH3Qb1tgVqUutc6d3VuWQkI1AM3+fJx8dkxzZs9t06qA27QgURYFoklpabuWpsUTzuKRpxleykp25E8m7tg==",
-      "requires": {
-        "@egjs/hammerjs": "^2.0.17",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      }
-    },
     "react-native-gradle-plugin": {
       "version": "0.71.16",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.16.tgz",
       "integrity": "sha512-H2BjG2zk7B7Wii9sXvd9qhCVRQYDAHSWdMw9tscmZBqSP62DkIWEQSk4/B2GhQ4aK9ydVXgtqR6tBeg3yy8TSA=="
-    },
-    "react-native-reanimated": {
-      "version": "2.14.4",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.14.4.tgz",
-      "integrity": "sha512-DquSbl7P8j4SAmc+kRdd75Ianm8G+IYQ9T4AQ6lrpLVeDkhZmjWI0wkutKWnp6L7c5XNVUrFDUf69dwETLCItQ==",
-      "requires": {
-        "@babel/plugin-transform-object-assign": "^7.16.7",
-        "@babel/preset-typescript": "^7.16.7",
-        "convert-source-map": "^1.7.0",
-        "invariant": "^2.2.4",
-        "lodash.isequal": "^4.5.0",
-        "setimmediate": "^1.0.5",
-        "string-hash-64": "^1.0.3"
-      }
-    },
-    "react-native-safe-area-context": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz",
-      "integrity": "sha512-0WORnk9SkREGUg2V7jHZbuN5x4vcxj/1B0QOcXJjdYWrzZHgLcUzYWWIUecUPJh747Mwjt/42RZDOaFn3L8kPQ==",
-      "requires": {}
-    },
-    "react-native-screens": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.20.0.tgz",
-      "integrity": "sha512-joWUKWAVHxymP3mL9gYApFHAsbd9L6ZcmpoZa6Sl3W/82bvvNVMqcfP7MeNqVCg73qZ8yL4fW+J/syusHleUgg==",
-      "requires": {
-        "react-freeze": "^1.0.0",
-        "warn-once": "^0.1.0"
-      }
-    },
-    "react-native-vector-icons": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.2.0.tgz",
-      "integrity": "sha512-wKYLaFuQST/chH3AJRjmOLoLy3JEs1JR6zMNgTaemFpNoXs0ztRnTxcxFD9xhX7cJe1/zoN5BpQYe7kL0m5yyA==",
-      "requires": {
-        "prop-types": "^15.7.2",
-        "yargs": "^16.1.1"
-      },
-      "dependencies": {
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
-        "y18n": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.9",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
-        }
-      }
     },
     "react-refresh": {
       "version": "0.4.3",
@@ -20819,21 +20114,6 @@
         }
       }
     },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-        }
-      }
-    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -21027,11 +20307,6 @@
         "through": "2"
       }
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -21117,11 +20392,6 @@
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg=="
     },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
-    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -21129,11 +20399,6 @@
       "requires": {
         "safe-buffer": "~5.2.0"
       }
-    },
-    "string-hash-64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string-hash-64/-/string-hash-64-1.0.3.tgz",
-      "integrity": "sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw=="
     },
     "string-width": {
       "version": "4.2.3",
@@ -21714,11 +20979,6 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
-    "use-latest-callback": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.1.5.tgz",
-      "integrity": "sha512-HtHatS2U4/h32NlkhupDsPlrbiD27gSH5swBdtXbCAlc6pfOFzaj0FehW/FO12rx8j2Vy4/lJScCiJyM01E+bQ=="
-    },
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -21770,11 +21030,6 @@
       "requires": {
         "makeerror": "1.0.12"
       }
-    },
-    "warn-once": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
-      "integrity": "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q=="
     },
     "wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "prepare": "husky install",
-    "extract-messages": "formatjs extract 'src/*.{ts,tsx}' --out-file ./messages/en.json"
+    "extract-messages": "formatjs extract 'src/*.{ts,tsx}' --format crowdin --out-file ./messages/en.json",
+    "build:translations": "node ./scripts/compile.js "
   },
   "dependencies": {
     "expo": "~48.0.6",
@@ -21,7 +22,9 @@
     "@babel/core": "^7.20.0",
     "@formatjs/cli": "^6.0.4",
     "@types/react": "~18.0.14",
+    "glob": "^9.3.0",
     "husky": "^8.0.0",
+    "mkdirp": "^2.1.5",
     "prettier": "^2.8.4",
     "pretty-quick": "^3.1.3",
     "typescript": "^4.9.4"

--- a/package.json
+++ b/package.json
@@ -7,28 +7,20 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "extract-messages": "formatjs extract 'src/*.{ts,tsx}' --out-file ./messages/en.json"
   },
   "dependencies": {
-    "@react-navigation/drawer": "^6.6.2",
-    "@react-navigation/native": "^6.1.6",
-    "@react-navigation/native-stack": "^6.9.12",
     "expo": "~48.0.6",
     "expo-status-bar": "~1.4.4",
-    "react": "18.2.0",
-    "react-intl": "^6.2.10",
-    "react-native": "0.71.3",
-    "react-native-gesture-handler": "~2.9.0",
-    "react-native-reanimated": "~2.14.4",
-    "react-native-safe-area-context": "^4.5.0",
-    "react-native-screens": "^3.20.0",
-    "react-native-vector-icons": "^9.2.0"
+    "react": "^18.2.0",
+    "react-intl": "^6.3.0",
+    "react-native": "0.71.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "@formatjs/cli": "^6.0.4",
     "@types/react": "~18.0.14",
-    "@types/react-native": "^0.71.3",
-    "@types/react-native-vector-icons": "^6.4.13",
     "husky": "^8.0.0",
     "prettier": "^2.8.4",
     "pretty-quick": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "./src/App.tsx",
   "scripts": {
-    "start": "expo start",
+    "start": "npm run build:translations && expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+const glob = require("glob");
+const util = require("util");
+const mkdirp = require("mkdirp");
+const rimraf = require("rimraf");
+const path = require("path");
+const fs = require("fs");
+const languageNameTranslations = require("../src/languages.json");
+
+const readFile = util.promisify(fs.readFile);
+const writeFile = util.promisify(fs.writeFile);
+
+async function readJson(file) {
+  return JSON.parse(await readFile(file));
+}
+
+async function writeJson(file, data) {
+  await mkdirp(path.dirname(file));
+  await writeFile(file, JSON.stringify(data, null, 2));
+}
+
+async function compile() {
+  rimraf.sync("translations/*");
+  const files = await glob("messages/**/*.json");
+  const allMsgs = {};
+  for (const file of files) {
+    const lang = path.parse(file).name;
+    const msgs = await readJson(file);
+    // If a language is added to Crowdin, but has no translated messages,
+    // Crowdin still creates an empty file, so we just ignore it
+    if (Object.keys(msgs).length === 0) continue;
+    if (!allMsgs[lang]) allMsgs[lang] = msgs;
+    else allMsgs[lang] = { ...allMsgs[lang], ...msgs };
+  }
+  const translations = {};
+  for (const lang in allMsgs) {
+    if (!languageNameTranslations[lang]) {
+      console.warn(`Locale '${lang}' has no language name defined in \`src/frontend/languages.json\`,
+    so it will not appear as a language option in Mapeo.
+    Add the language name in English and the native langague to \`languages.json\`
+    in order to allow users to select '${lang}' in Mapeo`);
+    }
+    translations[lang] = {};
+    const msgs = allMsgs[lang];
+    Object.keys(msgs).forEach((key) => {
+      if (!msgs[key].message) return;
+      translations[lang][key] = msgs[key].message;
+    });
+  }
+  const output = path.join(__dirname, "../translations/messages.json");
+  await writeJson(output, translations);
+}
+
+compile();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,13 @@
 import { registerRootComponent } from "expo";
+import { defineMessages } from "react-intl";
+
+const m = defineMessages({
+  firstMessage: {
+    id: "app.firstMessage",
+    defaultMessage: "This is a test",
+    description: "Used as a tester",
+  },
+});
 
 import { NavigationContainer } from "./navigation/NavigationContainer";
 import "react-native-gesture-handler";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { registerRootComponent } from "expo";
+import { IntlProvider } from "./contexts/IntlContext";
 import { defineMessages } from "react-intl";
 
 const m = defineMessages({
@@ -13,7 +14,11 @@ import { NavigationContainer } from "./navigation/NavigationContainer";
 import "react-native-gesture-handler";
 
 export default function App() {
-  return <NavigationContainer />;
+  return (
+    <IntlProvider>
+      <NavigationContainer />
+    </IntlProvider>
+  );
 }
 
 registerRootComponent(App);

--- a/src/contexts/IntlContext.tsx
+++ b/src/contexts/IntlContext.tsx
@@ -1,5 +1,95 @@
+import {
+  createContext,
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useMemo,
+  useState,
+} from "react";
 import { IntlProvider as ReactIntlProvider } from "react-intl";
+import messages from "../../translations/messages.json";
+import languages from "../languages.json";
 
-export const IntlProvider = () => {
-  return <></>;
+type TranslatedLocales = keyof typeof messages;
+type SupportedLanguageLocales = keyof typeof languages;
+interface LanguageName {
+  /** IETF BCP 47 langauge tag with region code. */
+  locale: SupportedLanguageLocales;
+  /** Localized name for language */
+  nativeName: string;
+  /** English name for language */
+  englishName: string;
+}
+
+const translatedLocales = Object.keys(messages) as Array<TranslatedLocales>;
+
+export const supportedLanguages: LanguageName[] = translatedLocales
+  .filter((locale) => {
+    const hasAtLeastOneTranslatedString =
+      Object.keys(messages[locale]).length > 0;
+    // This will show a typescript error if the language name does not exist
+    const hasTranslatedLanguageName = languages[locale];
+    if (!hasTranslatedLanguageName) {
+      console.warn(
+        `Locale "${locale}" is not available in Mapeo because we do not have
+a language name and translations in \`src/frontend/languages.json\``
+      );
+    }
+    return hasAtLeastOneTranslatedString && hasTranslatedLanguageName;
+  })
+  .map((locale) => ({
+    locale,
+    ...languages[locale],
+  }))
+  .sort((a, b) => {
+    return a.englishName.localeCompare(b.englishName);
+  });
+
+type IntlSetContextType = Readonly<
+  [string, Dispatch<SetStateAction<TranslatedLocales>>]
+>;
+
+const IntlSetContext = createContext<IntlSetContextType>(["en", () => {}]);
+
+export const IntlProvider = ({ children }: { children: ReactNode }) => {
+  const [appLocale, setAppLocale] = useState<TranslatedLocales>("en");
+
+  const locale = appLocale || getSupportedLocale(appLocale) || "en";
+
+  const languageCode = locale.split("-")[0];
+
+  // Add fallbacks for non-regional locales (e.g. "en" for "en-GB")
+  const localeMessages = {
+    ...messages[languageCode as TranslatedLocales],
+    ...(messages[locale as TranslatedLocales] || {}),
+  };
+
+  const contextValue = useMemo(
+    () => [locale, setAppLocale] as const,
+    [locale, setAppLocale]
+  );
+
+  console.log(translatedLocales);
+
+  return (
+    <ReactIntlProvider
+      locale={locale}
+      messages={localeMessages}
+      wrapRichTextChunksInFragment
+    >
+      <IntlSetContext.Provider value={contextValue}>
+        {children}
+      </IntlSetContext.Provider>
+    </ReactIntlProvider>
+  );
 };
+
+function getSupportedLocale(
+  locale: SupportedLanguageLocales
+): keyof typeof languages | undefined {
+  if (supportedLanguages.find((lang) => lang.locale === locale))
+    return locale as keyof typeof languages;
+  const nonRegionalLocale = locale.split("-")[0];
+  if (supportedLanguages.find(({ locale }) => locale === nonRegionalLocale))
+    return nonRegionalLocale as keyof typeof languages;
+}

--- a/src/contexts/IntlContext.tsx
+++ b/src/contexts/IntlContext.tsx
@@ -1,0 +1,5 @@
+import { IntlProvider as ReactIntlProvider } from "react-intl";
+
+export const IntlProvider = () => {
+  return <></>;
+};

--- a/src/languages.json
+++ b/src/languages.json
@@ -1,0 +1,874 @@
+{
+  "ach": {
+    "nativeName": "Lwo",
+    "englishName": "Acholi"
+  },
+  "ady": {
+    "nativeName": "Адыгэбзэ",
+    "englishName": "Adyghe"
+  },
+  "af": {
+    "nativeName": "Afrikaans",
+    "englishName": "Afrikaans"
+  },
+  "af-NA": {
+    "nativeName": "Afrikaans (Namibia)",
+    "englishName": "Afrikaans (Namibia)"
+  },
+  "af-ZA": {
+    "nativeName": "Afrikaans (South Africa)",
+    "englishName": "Afrikaans (South Africa)"
+  },
+  "ak": {
+    "nativeName": "Tɕɥi",
+    "englishName": "Akan"
+  },
+  "ar": {
+    "nativeName": "العربية",
+    "englishName": "Arabic"
+  },
+  "ar-AR": {
+    "nativeName": "العربية",
+    "englishName": "Arabic"
+  },
+  "ar-MA": {
+    "nativeName": "العربية",
+    "englishName": "Arabic (Morocco)"
+  },
+  "ar-SA": {
+    "nativeName": "العربية (السعودية)",
+    "englishName": "Arabic (Saudi Arabia)"
+  },
+  "ay-BO": {
+    "nativeName": "Aymar aru",
+    "englishName": "Aymara"
+  },
+  "az": {
+    "nativeName": "Azərbaycan dili",
+    "englishName": "Azerbaijani"
+  },
+  "az-AZ": {
+    "nativeName": "Azərbaycan dili",
+    "englishName": "Azerbaijani"
+  },
+  "be-BY": {
+    "nativeName": "Беларуская",
+    "englishName": "Belarusian"
+  },
+  "bg": {
+    "nativeName": "Български",
+    "englishName": "Bulgarian"
+  },
+  "bg-BG": {
+    "nativeName": "Български",
+    "englishName": "Bulgarian"
+  },
+  "bn": {
+    "nativeName": "বাংলা",
+    "englishName": "Bengali"
+  },
+  "bn-IN": {
+    "nativeName": "বাংলা (ভারত)",
+    "englishName": "Bengali (India)"
+  },
+  "bn-BD": {
+    "nativeName": "বাংলা(বাংলাদেশ)",
+    "englishName": "Bengali (Bangladesh)"
+  },
+  "bs-BA": {
+    "nativeName": "Bosanski",
+    "englishName": "Bosnian"
+  },
+  "ca": {
+    "nativeName": "Català",
+    "englishName": "Catalan"
+  },
+  "ca-ES": {
+    "nativeName": "Català",
+    "englishName": "Catalan"
+  },
+  "cak": {
+    "nativeName": "Maya Kaqchikel",
+    "englishName": "Kaqchikel"
+  },
+  "ck-US": {
+    "nativeName": "ᏣᎳᎩ (tsalagi)",
+    "englishName": "Cherokee"
+  },
+  "cs": {
+    "nativeName": "Čeština",
+    "englishName": "Czech"
+  },
+  "cs-CZ": {
+    "nativeName": "Čeština",
+    "englishName": "Czech"
+  },
+  "cy": {
+    "nativeName": "Cymraeg",
+    "englishName": "Welsh"
+  },
+  "cy-GB": {
+    "nativeName": "Cymraeg",
+    "englishName": "Welsh"
+  },
+  "da": {
+    "nativeName": "Dansk",
+    "englishName": "Danish"
+  },
+  "da-DK": {
+    "nativeName": "Dansk",
+    "englishName": "Danish"
+  },
+  "de": {
+    "nativeName": "Deutsch",
+    "englishName": "German"
+  },
+  "de-AT": {
+    "nativeName": "Deutsch (Österreich)",
+    "englishName": "German (Austria)"
+  },
+  "de-DE": {
+    "nativeName": "Deutsch (Deutschland)",
+    "englishName": "German (Germany)"
+  },
+  "de-CH": {
+    "nativeName": "Deutsch (Schweiz)",
+    "englishName": "German (Switzerland)"
+  },
+  "dsb": {
+    "nativeName": "Dolnoserbšćina",
+    "englishName": "Lower Sorbian"
+  },
+  "el": {
+    "nativeName": "Ελληνικά",
+    "englishName": "Greek"
+  },
+  "el-GR": {
+    "nativeName": "Ελληνικά",
+    "englishName": "Greek (Greece)"
+  },
+  "en": {
+    "nativeName": "English",
+    "englishName": "English"
+  },
+  "en-GB": {
+    "nativeName": "English (UK)",
+    "englishName": "English (UK)"
+  },
+  "en-AU": {
+    "nativeName": "English (Australia)",
+    "englishName": "English (Australia)"
+  },
+  "en-CA": {
+    "nativeName": "English (Canada)",
+    "englishName": "English (Canada)"
+  },
+  "en-IE": {
+    "nativeName": "English (Ireland)",
+    "englishName": "English (Ireland)"
+  },
+  "en-IN": {
+    "nativeName": "English (India)",
+    "englishName": "English (India)"
+  },
+  "en-PI": {
+    "nativeName": "English (Pirate)",
+    "englishName": "English (Pirate)"
+  },
+  "en-UD": {
+    "nativeName": "English (Upside Down)",
+    "englishName": "English (Upside Down)"
+  },
+  "en-US": {
+    "nativeName": "English (US)",
+    "englishName": "English (US)"
+  },
+  "en-ZA": {
+    "nativeName": "English (South Africa)",
+    "englishName": "English (South Africa)"
+  },
+  "en@pirate": {
+    "nativeName": "English (Pirate)",
+    "englishName": "English (Pirate)"
+  },
+  "eo": {
+    "nativeName": "Esperanto",
+    "englishName": "Esperanto"
+  },
+  "eo-EO": {
+    "nativeName": "Esperanto",
+    "englishName": "Esperanto"
+  },
+  "es": {
+    "nativeName": "Español",
+    "englishName": "Spanish"
+  },
+  "es-AR": {
+    "nativeName": "Español (Argentine)",
+    "englishName": "Spanish (Argentina)"
+  },
+  "es-419": {
+    "nativeName": "Español (Latinoamérica)",
+    "englishName": "Spanish (Latin America)"
+  },
+  "es-CL": {
+    "nativeName": "Español (Chile)",
+    "englishName": "Spanish (Chile)"
+  },
+  "es-CO": {
+    "nativeName": "Español (Colombia)",
+    "englishName": "Spanish (Colombia)"
+  },
+  "es-EC": {
+    "nativeName": "Español (Ecuador)",
+    "englishName": "Spanish (Ecuador)"
+  },
+  "es-ES": {
+    "nativeName": "Español (España)",
+    "englishName": "Spanish (Spain)"
+  },
+  "es-LA": {
+    "nativeName": "Español (Latinoamérica)",
+    "englishName": "Spanish (Latin America)"
+  },
+  "es-NI": {
+    "nativeName": "Español (Nicaragua)",
+    "englishName": "Spanish (Nicaragua)"
+  },
+  "es-MX": {
+    "nativeName": "Español (México)",
+    "englishName": "Spanish (Mexico)"
+  },
+  "es-US": {
+    "nativeName": "Español (Estados Unidos)",
+    "englishName": "Spanish (United States)"
+  },
+  "es-VE": {
+    "nativeName": "Español (Venezuela)",
+    "englishName": "Spanish (Venezuela)"
+  },
+  "et": {
+    "nativeName": "eesti keel",
+    "englishName": "Estonian"
+  },
+  "et-EE": {
+    "nativeName": "Eesti (Estonia)",
+    "englishName": "Estonian (Estonia)"
+  },
+  "eu": {
+    "nativeName": "Euskara",
+    "englishName": "Basque"
+  },
+  "eu-ES": {
+    "nativeName": "Euskara",
+    "englishName": "Basque"
+  },
+  "fa": {
+    "nativeName": "فارسی",
+    "englishName": "Persian"
+  },
+  "fa-IR": {
+    "nativeName": "فارسی",
+    "englishName": "Persian"
+  },
+  "fb-LT": {
+    "nativeName": "Leet Speak",
+    "englishName": "Leet"
+  },
+  "ff": {
+    "nativeName": "Fulah",
+    "englishName": "Fulah"
+  },
+  "fi": {
+    "nativeName": "Suomi",
+    "englishName": "Finnish"
+  },
+  "fi-FI": {
+    "nativeName": "Suomi",
+    "englishName": "Finnish"
+  },
+  "fo-FO": {
+    "nativeName": "Føroyskt",
+    "englishName": "Faroese"
+  },
+  "fr": {
+    "nativeName": "Français",
+    "englishName": "French"
+  },
+  "fr-CA": {
+    "nativeName": "Français (Canada)",
+    "englishName": "French (Canada)"
+  },
+  "fr-FR": {
+    "nativeName": "Français (France)",
+    "englishName": "French (France)"
+  },
+  "fr-BE": {
+    "nativeName": "Français (Belgique)",
+    "englishName": "French (Belgium)"
+  },
+  "fr-CH": {
+    "nativeName": "Français (Suisse)",
+    "englishName": "French (Switzerland)"
+  },
+  "fy-NL": {
+    "nativeName": "Frysk",
+    "englishName": "Frisian (West)"
+  },
+  "ga": {
+    "nativeName": "Gaeilge",
+    "englishName": "Irish"
+  },
+  "ga-IE": {
+    "nativeName": "Gaeilge (Gaelic)",
+    "englishName": "Irish (Gaelic)"
+  },
+  "gl": {
+    "nativeName": "Galego",
+    "englishName": "Galician"
+  },
+  "gl-ES": {
+    "nativeName": "Galego",
+    "englishName": "Galician"
+  },
+  "gn-PY": {
+    "nativeName": "Avañe'ẽ",
+    "englishName": "Guarani"
+  },
+  "gu-IN": {
+    "nativeName": "ગુજરાતી",
+    "englishName": "Gujarati"
+  },
+  "gx-GR": {
+    "nativeName": "Ἑλληνική ἀρχαία",
+    "englishName": "Classical Greek"
+  },
+  "he": {
+    "nativeName": "עברית‏",
+    "englishName": "Hebrew"
+  },
+  "he-IL": {
+    "nativeName": "עברית‏",
+    "englishName": "Hebrew"
+  },
+  "hi": {
+    "nativeName": "हिन्दी",
+    "englishName": "Hindi"
+  },
+  "hi-IN": {
+    "nativeName": "हिन्दी",
+    "englishName": "Hindi"
+  },
+  "hr": {
+    "nativeName": "Hrvatski",
+    "englishName": "Croatian"
+  },
+  "hr-HR": {
+    "nativeName": "Hrvatski",
+    "englishName": "Croatian"
+  },
+  "hsb": {
+    "nativeName": "Hornjoserbšćina",
+    "englishName": "Upper Sorbian"
+  },
+  "ht": {
+    "nativeName": "Kreyòl",
+    "englishName": "Haitian Creole"
+  },
+  "hu": {
+    "nativeName": "Magyar",
+    "englishName": "Hungarian"
+  },
+  "hu-HU": {
+    "nativeName": "Magyar",
+    "englishName": "Hungarian"
+  },
+  "hy-AM": {
+    "nativeName": "Հայերեն",
+    "englishName": "Armenian"
+  },
+  "id": {
+    "nativeName": "Bahasa Indonesia",
+    "englishName": "Indonesian"
+  },
+  "id-ID": {
+    "nativeName": "Bahasa Indonesia",
+    "englishName": "Indonesian"
+  },
+  "is": {
+    "nativeName": "Íslenska",
+    "englishName": "Icelandic"
+  },
+  "is-IS": {
+    "nativeName": "Íslenska (Iceland)",
+    "englishName": "Icelandic (Iceland)"
+  },
+  "it": {
+    "nativeName": "Italiano",
+    "englishName": "Italian"
+  },
+  "it-IT": {
+    "nativeName": "Italiano",
+    "englishName": "Italian"
+  },
+  "ja": {
+    "nativeName": "日本語",
+    "englishName": "Japanese"
+  },
+  "ja-JP": {
+    "nativeName": "日本語",
+    "englishName": "Japanese"
+  },
+  "jv-ID": {
+    "nativeName": "Basa Jawa",
+    "englishName": "Javanese"
+  },
+  "ka-GE": {
+    "nativeName": "ქართული",
+    "englishName": "Georgian"
+  },
+  "kk-KZ": {
+    "nativeName": "Қазақша",
+    "englishName": "Kazakh"
+  },
+  "km": {
+    "nativeName": "ភាសាខ្មែរ",
+    "englishName": "Khmer"
+  },
+  "km-KH": {
+    "nativeName": "ភាសាខ្មែរ",
+    "englishName": "Khmer"
+  },
+  "kab": {
+    "nativeName": "Taqbaylit",
+    "englishName": "Kabyle"
+  },
+  "kn": {
+    "nativeName": "ಕನ್ನಡ",
+    "englishName": "Kannada"
+  },
+  "kn-IN": {
+    "nativeName": "ಕನ್ನಡ (India)",
+    "englishName": "Kannada (India)"
+  },
+  "ko": {
+    "nativeName": "한국어",
+    "englishName": "Korean"
+  },
+  "ko-KR": {
+    "nativeName": "한국어 (韩国)",
+    "englishName": "Korean (Korea)"
+  },
+  "ku-TR": {
+    "nativeName": "Kurdî",
+    "englishName": "Kurdish"
+  },
+  "la": {
+    "nativeName": "Latin",
+    "englishName": "Latin"
+  },
+  "la-VA": {
+    "nativeName": "Latin",
+    "englishName": "Latin"
+  },
+  "lb": {
+    "nativeName": "Lëtzebuergesch",
+    "englishName": "Luxembourgish"
+  },
+  "li-NL": {
+    "nativeName": "Lèmbörgs",
+    "englishName": "Limburgish"
+  },
+  "lo": {
+    "nativeName": "ພາສາລາວ",
+    "englishName": "Lao"
+  },
+  "lt": {
+    "nativeName": "Lietuvių",
+    "englishName": "Lithuanian"
+  },
+  "lt-LT": {
+    "nativeName": "Lietuvių",
+    "englishName": "Lithuanian"
+  },
+  "lv": {
+    "nativeName": "Latviešu",
+    "englishName": "Latvian"
+  },
+  "lv-LV": {
+    "nativeName": "Latviešu",
+    "englishName": "Latvian"
+  },
+  "mai": {
+    "nativeName": "मैथिली, মৈথিলী",
+    "englishName": "Maithili"
+  },
+  "mg": {
+    "nativeName": "Malagasy",
+    "englishName": "Malagasy"
+  },
+  "mg-MG": {
+    "nativeName": "Malagasy",
+    "englishName": "Malagasy"
+  },
+  "mk": {
+    "nativeName": "Македонски",
+    "englishName": "Macedonian"
+  },
+  "mk-MK": {
+    "nativeName": "Македонски (Македонски)",
+    "englishName": "Macedonian (Macedonian)"
+  },
+  "ml": {
+    "nativeName": "മലയാളം",
+    "englishName": "Malayalam"
+  },
+  "ml-IN": {
+    "nativeName": "മലയാളം",
+    "englishName": "Malayalam"
+  },
+  "mn-MN": {
+    "nativeName": "Монгол",
+    "englishName": "Mongolian"
+  },
+  "mr": {
+    "nativeName": "मराठी",
+    "englishName": "Marathi"
+  },
+  "mr-IN": {
+    "nativeName": "मराठी",
+    "englishName": "Marathi"
+  },
+  "ms": {
+    "nativeName": "Bahasa Melayu",
+    "englishName": "Malay"
+  },
+  "ms-MY": {
+    "nativeName": "Bahasa Melayu",
+    "englishName": "Malay"
+  },
+  "mt": {
+    "nativeName": "Malti",
+    "englishName": "Maltese"
+  },
+  "mt-MT": {
+    "nativeName": "Malti",
+    "englishName": "Maltese"
+  },
+  "my": {
+    "nativeName": "ဗမာစကာ",
+    "englishName": "Burmese"
+  },
+  "no": {
+    "nativeName": "Norsk",
+    "englishName": "Norwegian"
+  },
+  "nb": {
+    "nativeName": "Norsk (bokmål)",
+    "englishName": "Norwegian (bokmal)"
+  },
+  "nb-NO": {
+    "nativeName": "Norsk (bokmål)",
+    "englishName": "Norwegian (bokmal)"
+  },
+  "ne": {
+    "nativeName": "नेपाली",
+    "englishName": "Nepali"
+  },
+  "ne-NP": {
+    "nativeName": "नेपाली",
+    "englishName": "Nepali"
+  },
+  "nl": {
+    "nativeName": "Nederlands",
+    "englishName": "Dutch"
+  },
+  "nl-BE": {
+    "nativeName": "Nederlands (België)",
+    "englishName": "Dutch (Belgium)"
+  },
+  "nl-NL": {
+    "nativeName": "Nederlands (Nederland)",
+    "englishName": "Dutch (Netherlands)"
+  },
+  "nn-NO": {
+    "nativeName": "Norsk (nynorsk)",
+    "englishName": "Norwegian (nynorsk)"
+  },
+  "oc": {
+    "nativeName": "Occitan",
+    "englishName": "Occitan"
+  },
+  "oki": {
+    "nativeName": "Ogiek",
+    "englishName": "Ogiek"
+  },
+  "or-IN": {
+    "nativeName": "ଓଡ଼ିଆ",
+    "englishName": "Oriya"
+  },
+  "pa": {
+    "nativeName": "ਪੰਜਾਬੀ",
+    "englishName": "Punjabi"
+  },
+  "pa-IN": {
+    "nativeName": "ਪੰਜਾਬੀ (ਭਾਰਤ ਨੂੰ)",
+    "englishName": "Punjabi (India)"
+  },
+  "pl": {
+    "nativeName": "Polski",
+    "englishName": "Polish"
+  },
+  "pl-PL": {
+    "nativeName": "Polski",
+    "englishName": "Polish"
+  },
+  "ps-AF": {
+    "nativeName": "پښتو",
+    "englishName": "Pashto"
+  },
+  "pt": {
+    "nativeName": "Português",
+    "englishName": "Portuguese"
+  },
+  "pt-BR": {
+    "nativeName": "Português (Brasil)",
+    "englishName": "Portuguese (Brazil)"
+  },
+  "pt-PT": {
+    "nativeName": "Português (Portugal)",
+    "englishName": "Portuguese (Portugal)"
+  },
+  "qu-PE": {
+    "nativeName": "Qhichwa",
+    "englishName": "Quechua"
+  },
+  "rm-CH": {
+    "nativeName": "Rumantsch",
+    "englishName": "Romansh"
+  },
+  "ro": {
+    "nativeName": "Română",
+    "englishName": "Romanian"
+  },
+  "ro-RO": {
+    "nativeName": "Română",
+    "englishName": "Romanian"
+  },
+  "ru": {
+    "nativeName": "Русский",
+    "englishName": "Russian"
+  },
+  "ru-RU": {
+    "nativeName": "Русский",
+    "englishName": "Russian"
+  },
+  "sa-IN": {
+    "nativeName": "संस्कृतम्",
+    "englishName": "Sanskrit"
+  },
+  "se-NO": {
+    "nativeName": "Davvisámegiella",
+    "englishName": "Northern Sámi"
+  },
+  "si": {
+    "nativeName": "පළාත",
+    "englishName": "Sinhala (Sri Lanka)"
+  },
+  "si-LK": {
+    "nativeName": "පළාත",
+    "englishName": "Sinhala (Sri Lanka)"
+  },
+  "sk": {
+    "nativeName": "Slovenčina",
+    "englishName": "Slovak"
+  },
+  "sk-SK": {
+    "nativeName": "Slovenčina (Slovakia)",
+    "englishName": "Slovak (Slovakia)"
+  },
+  "sl": {
+    "nativeName": "Slovenščina",
+    "englishName": "Slovenian"
+  },
+  "sl-SI": {
+    "nativeName": "Slovenščina",
+    "englishName": "Slovenian"
+  },
+  "so-SO": {
+    "nativeName": "Soomaaliga",
+    "englishName": "Somali"
+  },
+  "sq": {
+    "nativeName": "Shqip",
+    "englishName": "Albanian"
+  },
+  "sq-AL": {
+    "nativeName": "Shqip",
+    "englishName": "Albanian"
+  },
+  "sr": {
+    "nativeName": "Српски",
+    "englishName": "Serbian"
+  },
+  "sr-RS": {
+    "nativeName": "Српски (Serbia)",
+    "englishName": "Serbian (Serbia)"
+  },
+  "srn": {
+    "nativeName": "Sranan Tongo",
+    "englishName": "Sranan Tongo"
+  },
+  "su": {
+    "nativeName": "Basa Sunda",
+    "englishName": "Sundanese"
+  },
+  "sv": {
+    "nativeName": "Svenska",
+    "englishName": "Swedish"
+  },
+  "sv-SE": {
+    "nativeName": "Svenska",
+    "englishName": "Swedish"
+  },
+  "sw": {
+    "nativeName": "Kiswahili",
+    "englishName": "Swahili"
+  },
+  "sw-KE": {
+    "nativeName": "Kiswahili",
+    "englishName": "Swahili (Kenya)"
+  },
+  "ta": {
+    "nativeName": "தமிழ்",
+    "englishName": "Tamil"
+  },
+  "ta-IN": {
+    "nativeName": "தமிழ்",
+    "englishName": "Tamil"
+  },
+  "te": {
+    "nativeName": "తెలుగు",
+    "englishName": "Telugu"
+  },
+  "te-IN": {
+    "nativeName": "తెలుగు",
+    "englishName": "Telugu"
+  },
+  "tg": {
+    "nativeName": "забо́ни тоҷикӣ́",
+    "englishName": "Tajik"
+  },
+  "tg-TJ": {
+    "nativeName": "тоҷикӣ",
+    "englishName": "Tajik"
+  },
+  "th": {
+    "nativeName": "ภาษาไทย",
+    "englishName": "Thai"
+  },
+  "th-TH": {
+    "nativeName": "ภาษาไทย (ประเทศไทย)",
+    "englishName": "Thai (Thailand)"
+  },
+  "tl": {
+    "nativeName": "Filipino",
+    "englishName": "Filipino"
+  },
+  "tl-PH": {
+    "nativeName": "Filipino",
+    "englishName": "Filipino"
+  },
+  "tlh": {
+    "nativeName": "tlhIngan-Hol",
+    "englishName": "Klingon"
+  },
+  "tr": {
+    "nativeName": "Türkçe",
+    "englishName": "Turkish"
+  },
+  "tr-TR": {
+    "nativeName": "Türkçe",
+    "englishName": "Turkish"
+  },
+  "tt-RU": {
+    "nativeName": "татарча",
+    "englishName": "Tatar"
+  },
+  "uk": {
+    "nativeName": "Українська",
+    "englishName": "Ukrainian"
+  },
+  "uk-UA": {
+    "nativeName": "Українська",
+    "englishName": "Ukrainian"
+  },
+  "ur": {
+    "nativeName": "اردو",
+    "englishName": "Urdu"
+  },
+  "ur-PK": {
+    "nativeName": "اردو",
+    "englishName": "Urdu"
+  },
+  "uz": {
+    "nativeName": "O'zbek",
+    "englishName": "Uzbek"
+  },
+  "uz-UZ": {
+    "nativeName": "O'zbek",
+    "englishName": "Uzbek"
+  },
+  "vi": {
+    "nativeName": "Tiếng Việt",
+    "englishName": "Vietnamese"
+  },
+  "vi-VN": {
+    "nativeName": "Tiếng Việt",
+    "englishName": "Vietnamese"
+  },
+  "xh-ZA": {
+    "nativeName": "isiXhosa",
+    "englishName": "Xhosa"
+  },
+  "yi": {
+    "nativeName": "ייִדיש",
+    "englishName": "Yiddish"
+  },
+  "yi-DE": {
+    "nativeName": "ייִדיש (German)",
+    "englishName": "Yiddish (German)"
+  },
+  "zh": {
+    "nativeName": "中文",
+    "englishName": "Chinese"
+  },
+  "zh-Hans": {
+    "nativeName": "中文简体",
+    "englishName": "Chinese Simplified"
+  },
+  "zh-Hant": {
+    "nativeName": "中文繁體",
+    "englishName": "Chinese Traditional"
+  },
+  "zh-CN": {
+    "nativeName": "中文（中国）",
+    "englishName": "Chinese Simplified (China)"
+  },
+  "zh-HK": {
+    "nativeName": "中文（香港）",
+    "englishName": "Chinese Traditional (Hong Kong)"
+  },
+  "zh-SG": {
+    "nativeName": "中文（新加坡）",
+    "englishName": "Chinese Simplified (Singapore)"
+  },
+  "zh-TW": {
+    "nativeName": "中文（台灣）",
+    "englishName": "Chinese Traditional (Taiwan)"
+  },
+  "zu-ZA": {
+    "nativeName": "isiZulu",
+    "englishName": "Zulu"
+  }
+}

--- a/translations/messages.json
+++ b/translations/messages.json
@@ -1,0 +1,5 @@
+{
+  "en": {
+    "app.firstMessage": "This is a test"
+  }
+}

--- a/translations/messages.json
+++ b/translations/messages.json
@@ -1,5 +1,0 @@
-{
-  "en": {
-    "app.firstMessage": "This is a test"
-  }
-}


### PR DESCRIPTION
# Added React-Intl, FormatJS, Crowdin Integration, and Script to build translations

## Crowdin
- Created [Crowdin Account](https://crowdin.com/project/mapeo-shell-app) for crowd sourced translations
- Added a `crowdin.yml` for crowding configuration. Messages from `Messages` folder are synced every 12 hours

## FormatJS CLI
- Messages are extracted from all front-end files and compiled into `Messages` folder
- Uses [extract script](https://formatjs.io/docs/getting-started/message-extraction) with built in crowdin formatting
- Extract script added to pre-commit step

## React Intl
- Uses 'react-int' to define translatable messages using [`formattedMessage`](https://formatjs.io/docs/react-intl/components#formattedmessage)
- Uses IntlProvider to translate messages to front-end

## Compile Script
- Located in `scripts/compile.js`
- Compile scrips takes all messages from 'messages' folder, and compiles in them into one file in `translations/messages.json`
- Crowdin uploads empty files in `messages` if the translation exists, but there are no translation. Those messages are not compiled to `translations/messages.json`
