### PR TITLE
feat: Added Zustand Sync Store and Hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react-native-reanimated": "~2.14.4",
         "react-native-safe-area-context": "4.5.0",
         "react-native-screens": "~3.20.0",
-        "react-native-vector-icons": "^9.2.0"
+        "react-native-vector-icons": "^9.2.0",
+        "zustand": "^4.3.6"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -12875,6 +12876,29 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zustand": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.6.tgz",
+      "integrity": "sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     }
   },
   "dependencies": {
@@ -22675,6 +22699,14 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zustand": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.6.tgz",
+      "integrity": "sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==",
+      "requires": {
+        "use-sync-external-store": "1.2.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",
-    "react-native-vector-icons": "^9.2.0"
+    "react-native-vector-icons": "^9.2.0",
+    "zustand": "^4.3.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/hooks/stores/useSyncStore.ts
+++ b/src/hooks/stores/useSyncStore.ts
@@ -71,6 +71,6 @@ export function useSetIndividualSync(deviceId: string) {
         (upload: Progress, download: Progress) =>
           setIndivdualSync(deviceId, upload, download),
       ] as const,
-    [thisSync, setIndivdualSync(deviceId)]
+    [thisSync, setIndivdualSync, deviceId]
   );
 }

--- a/src/hooks/stores/useSyncStore.ts
+++ b/src/hooks/stores/useSyncStore.ts
@@ -1,0 +1,76 @@
+import { useMemo } from "react";
+import { create } from "zustand";
+
+type Progress = {
+  completed: number;
+  total: number;
+};
+
+type ActiveSync = {
+  upload: Progress;
+  download: Progress;
+  isCompleted: boolean;
+};
+
+type AllSyncs = Record<string, ActiveSync>;
+
+type SyncStore = {
+  allSyncs: AllSyncs;
+  setIndivdualSync: (
+    deviceId: string,
+    upload?: Progress,
+    download?: Progress
+  ) => void;
+};
+
+const useSyncStore = create<SyncStore>()((set) => ({
+  allSyncs: {},
+  setIndivdualSync: (deviceId, upload, download) =>
+    set((state) => ({
+      ...state,
+      allSyncs: {
+        ...state.allSyncs,
+        [deviceId]: {
+          isCompleted:
+            !upload || !download
+              ? false
+              : upload.completed === upload.total &&
+                download.completed === download.total,
+          upload: upload || { completed: 0, total: 0 },
+          download: download || { completed: 0, total: 0 },
+        },
+      },
+    })),
+}));
+
+export function useIncompleteSyncs() {
+  const allSyncs = useSyncStore((state) => state.allSyncs);
+  return Object.entries(allSyncs)
+    .filter(([, values]) => !values.isCompleted)
+    .map(([key]) => allSyncs[key]);
+}
+
+/**
+ *
+ * @param deviceId
+ * @returns an array with [sync, setSync]
+ */
+export function useSetIndividualSync(deviceId: string) {
+  const allSyncs = useSyncStore((state) => state.allSyncs);
+  const setIndivdualSync = useSyncStore((store) => store.setIndivdualSync);
+
+  const thisSync = useMemo(() => allSyncs[deviceId], [allSyncs, deviceId]);
+  if (!thisSync) {
+    setIndivdualSync(deviceId);
+  }
+
+  return useMemo(
+    () =>
+      [
+        thisSync,
+        (upload: Progress, download: Progress) =>
+          setIndivdualSync(deviceId, upload, download),
+      ] as const,
+    [thisSync, setIndivdualSync(deviceId)]
+  );
+}

--- a/src/hooks/stores/useSyncStore.ts
+++ b/src/hooks/stores/useSyncStore.ts
@@ -21,6 +21,7 @@ type SyncStore = {
     upload?: Progress,
     download?: Progress
   ) => void;
+  resetSyncStore: () => void;
 };
 
 const useSyncStore = create<SyncStore>()((set) => ({
@@ -40,6 +41,11 @@ const useSyncStore = create<SyncStore>()((set) => ({
           download: download || { completed: 0, total: 0 },
         },
       },
+    })),
+  resetSyncStore: () =>
+    set((state) => ({
+      ...state,
+      allSyncs: {},
     })),
 }));
 
@@ -73,4 +79,11 @@ export function useIndividualSync(deviceId: string) {
       ] as const,
     [thisSync, setIndivdualSync, deviceId]
   );
+}
+
+/**
+ * @description calling this function will reset sync store. Should be used in cleanup when unmounting the sync screen
+ */
+export function useResetSyncStore() {
+  useSyncStore((store) => store.resetSyncStore)();
 }

--- a/src/hooks/stores/useSyncStore.ts
+++ b/src/hooks/stores/useSyncStore.ts
@@ -24,7 +24,6 @@ const emptyProgress: Progress = {
   total: 0,
 };
 
-// make upload and download optional
 const useSyncStore = create<SyncStore>()((set) => ({
   allSyncs: {},
   setIndivdualSync: (deviceId, progress) =>

--- a/src/hooks/stores/useSyncStore.ts
+++ b/src/hooks/stores/useSyncStore.ts
@@ -55,7 +55,7 @@ export function useIncompleteSyncs() {
  * @param deviceId
  * @returns an array with [sync, setSync]
  */
-export function useSetIndividualSync(deviceId: string) {
+export function useIndividualSync(deviceId: string) {
   const allSyncs = useSyncStore((state) => state.allSyncs);
   const setIndivdualSync = useSyncStore((store) => store.setIndivdualSync);
 


### PR DESCRIPTION
# Zustand Store
Created a zustand store that keeps track of individual sync progress, both the upload and download state. The total progress is derived from upload and download state combined. Zustand store also holds all sync, to keep track of overall syncs

# Sync Store Hooks
- `useIndividualSync`: takes a deviceID, and keeps track of the state of that devices sync state, including upload, download and total progress, where total is derive from upload and download
- `useIncompleteSyncs`:returns an array of all ACTIVE syncs
- 'useResetSyncStore`: function that resets the sync store. To be used as a clean up function when un-mounting sync screen