### PR TITLE
implement shared button component

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -86,13 +86,13 @@ export const Button = ({
         {iconName && (
           <MaterialIcon
             name={iconName}
-            size={textStyles.large.fontSize}
+            size={textStyles.medium.fontSize}
             color={buttonVariant === "primary" ? colors.WHITE : accentColor}
             style={styles.icon}
           />
         )}
         <Text
-          size="medium"
+          size="smallMedium"
           bold
           color={buttonVariant === "primary" ? colors.WHITE : accentColor}
         >

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,120 @@
+import * as React from "react";
+import {
+  GestureResponderEvent,
+  Pressable,
+  StyleSheet,
+  View,
+} from "react-native";
+import MaterialIcon from "react-native-vector-icons/MaterialCommunityIcons";
+
+import { colors, spacing } from "../lib/styles";
+import { Text, styles as textStyles } from "./Text";
+
+const HIT_SLOP = {
+  top: spacing.small,
+  right: spacing.small,
+  bottom: spacing.small,
+  left: spacing.small,
+};
+
+interface ButtonProps extends React.PropsWithChildren {
+  asText?: boolean;
+  borderless?: boolean;
+  fullWidth?: boolean;
+  iconName?: React.ComponentProps<typeof MaterialIcon>["name"];
+  onPress: (event: GestureResponderEvent) => void;
+  text: string;
+  type?: "destructive" | "normal";
+  variant?: "primary" | "secondary";
+}
+
+export const Button = ({
+  asText,
+  borderless,
+  fullWidth,
+  iconName,
+  onPress,
+  text,
+  type,
+  variant,
+}: ButtonProps) => {
+  const buttonType = type || "normal";
+  const buttonVariant = variant || "primary";
+
+  const [width, setWidth] = React.useState<number>(0);
+
+  const accentColor =
+    buttonType === "normal" ? colors.MAPEO_BLUE : colors.WARNING_RED;
+
+  return (
+    <View
+      style={styles.container}
+      onLayout={({ nativeEvent: { layout } }) => {
+        if (layout.width) setWidth(layout.width);
+      }}
+    >
+      <Pressable
+        onPress={onPress}
+        hitSlop={HIT_SLOP}
+        android_ripple={
+          !asText
+            ? {
+                color: colors.WHITE,
+                radius: width,
+                foreground: true,
+              }
+            : undefined
+        }
+        style={({ pressed }) => {
+          return [
+            styles.pressable,
+            {
+              flex: asText || !fullWidth ? 0 : 1,
+              justifyContent: asText ? "flex-start" : "center",
+              paddingVertical: asText ? 0 : spacing.medium,
+              paddingHorizontal: asText ? 0 : spacing.large,
+              backgroundColor:
+                buttonVariant === "primary" ? accentColor : colors.WHITE,
+              borderColor:
+                buttonVariant === "primary" ? accentColor : colors.GRAY,
+              borderWidth: asText || borderless ? 0 : 1,
+              opacity: asText && pressed ? 0.4 : 1,
+            },
+          ];
+        }}
+      >
+        {iconName && (
+          <MaterialIcon
+            name={iconName}
+            size={textStyles.large.fontSize}
+            color={buttonVariant === "primary" ? colors.WHITE : accentColor}
+            style={styles.icon}
+          />
+        )}
+        <Text
+          size="medium"
+          bold
+          color={buttonVariant === "primary" ? colors.WHITE : accentColor}
+        >
+          {text}
+        </Text>
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: colors.WHITE,
+  },
+  pressable: {
+    flexDirection: "row",
+    borderRadius: 4,
+  },
+  icon: {
+    marginRight: spacing.small,
+    paddingTop: spacing.small / 2,
+  },
+});

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -3,12 +3,13 @@ import { StyleSheet, Text as RNText, TextProps, TextStyle } from "react-native";
 interface Props extends React.PropsWithChildren<Omit<TextProps, "style">> {
   bold?: boolean;
   color?: TextStyle["color"];
-  size: "small" | "medium" | "large";
+  size: "small" | "smallMedium" | "medium" | "large";
   textAlign?: TextStyle["textAlign"];
 }
 
 export const styles = StyleSheet.create({
   small: { fontSize: 14 },
+  smallMedium: { fontSize: 16 },
   medium: { fontSize: 20 },
   large: { fontSize: 24 },
   bold: { fontWeight: "500" },

--- a/src/lib/styles.ts
+++ b/src/lib/styles.ts
@@ -14,4 +14,5 @@ export const colors = {
   MAPEO_BLUE: "#0066FF",
   MAPEO_DARK_BLUE: "#19337F",
   DARK_BLUE: "#000033",
+  WARNING_RED: "#D92222",
 } as const;

--- a/src/screens/sync/Devices.tsx
+++ b/src/screens/sync/Devices.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Animated, Pressable, View, StyleSheet } from "react-native";
+import { Animated, View, StyleSheet } from "react-native";
 import { defineMessages, useIntl } from "react-intl";
 import { useFocusEffect } from "@react-navigation/native";
 import { TouchableOpacity } from "react-native-gesture-handler";
@@ -10,6 +10,7 @@ import { Text, styles as textStyles } from "../../components/Text";
 import { colors, spacing } from "../../lib/styles";
 import { ProgressBar } from "../../components/ProgressBar";
 import { TitleAndDescription } from "../../components/SyncGroupBottomSheet";
+import { Button } from "../../components/Button";
 
 const m = defineMessages({
   searching: {
@@ -122,17 +123,6 @@ const deviceListStyles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
   },
-  syncButton: {
-    backgroundColor: colors.MAPEO_BLUE,
-    borderRadius: 4,
-    padding: spacing.medium,
-    minWidth: 120,
-  },
-  syncButtonContentContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-  },
   listHeaderContainer: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -169,23 +159,11 @@ export const DeviceList = ({
             <MaterialIcon name="help" size={14} color={colors.DARK_GRAY} />
           </TouchableOpacity>
         </View>
-        <Pressable
+        <Button
+          iconName="lightning-bolt"
           onPress={() => setShouldStart(true)}
-          android_ripple={{ radius: 100 }}
-          style={deviceListStyles.syncButton}
-        >
-          <View style={deviceListStyles.syncButtonContentContainer}>
-            <MaterialIcon
-              name="lightning-bolt"
-              size={20}
-              color={colors.WHITE}
-            />
-            <Spacer direction="horizontal" size={spacing.medium} />
-            <Text size="medium" color={colors.WHITE} bold>
-              {t(m.sync)}
-            </Text>
-          </View>
-        </Pressable>
+          text={t(m.sync)}
+        />
       </View>
       <View style={deviceListStyles.listHeaderContainer}>
         <Text size="small" color={colors.DARK_GRAY}>


### PR DESCRIPTION
Towards #20, #21, #22

started working on this as part of the pre-sync bottom sheets but figured it would make sense to extract to improve PR diffs

Notes: 

- implements a text-based button component that will be useful for various screen states. implementation accounts for the following button types and variants for each (screenshots are from the figma mockups, not actual component usage):

  - text-like 
    
    ![image](https://user-images.githubusercontent.com/18542095/231606660-fb55a85e-f6ed-45f6-b0f4-e97637bdc6da.png)

  - primary:
  
    ![image](https://user-images.githubusercontent.com/18542095/231606707-c9027d9d-5fee-4282-a72e-a99c78c92a8e.png)
  
  - secondary:
  
    ![image](https://user-images.githubusercontent.com/18542095/231606773-f44cf1ae-f58d-4b76-b95f-ae80d10c829c.png)

- only used for the Sync button in the devices screen so far. plan is to use this for the bottom sheet contents as well

---

Preview:

<img width="300" alt="Screen Shot 2023-04-17 at 1 24 53 PM" src="https://user-images.githubusercontent.com/18542095/232563002-24c5120d-fc7b-4aaf-ac6a-12bad2b4e9f7.png">

