### PR TITLE
Es/crowdin copy deck

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,3 @@
 files:
-  - source: /messages/en.json
+  - source: /messages/copy.json
     translation: /messages/%two_letters_code%.json

--- a/messages/copy.json
+++ b/messages/copy.json
@@ -1,0 +1,66 @@
+{
+  "Components.DeviceInfoContents.downloading": {
+    "message": "Downloading"
+  },
+  "Components.DeviceInfoContents.downloads": {
+    "message": "Downloads"
+  },
+  "Components.DeviceInfoContents.media": {
+    "message": "media"
+  },
+  "Components.DeviceInfoContents.observations": {
+    "message": "observations"
+  },
+  "Components.DeviceInfoContents.syncing": {
+    "message": "Syncing"
+  },
+  "Components.DeviceInfoContents.uploading": {
+    "message": "Uploading"
+  },
+  "Components.DeviceInfoContents.uploads": {
+    "message": "Uploads"
+  },
+  "app.firstMessage": {
+    "description": "Used as a tester",
+    "message": "This is a test"
+  },
+  "screen.Home.coordinatorButtonText": {
+    "message": "Sync (as Coordinator)"
+  },
+  "screen.Home.participantButtonText": {
+    "message": "Sync (as Participant)"
+  },
+  "screen.Home.subtitle": {
+    "message": "Sync"
+  },
+  "screen.Home.title": {
+    "message": "Mapeo Mobile Testing"
+  },
+  "screen.sync.Devices.searching": {
+    "message": "Searching for devices"
+  },
+  "screen.sync.ProjectInfo.connectedNoNetworkName": {
+    "message": "Connected (no network name)"
+  },
+  "screen.sync.ProjectInfo.noConnection": {
+    "message": "No connection"
+  },
+  "screen.sync.index.navTitle": {
+    "message": "Synchronize"
+  },
+  "screen.sync.main.deviceName": {
+    "message": "Device Name"
+  },
+  "screen.sync.main.lastSynced": {
+    "message": "Last Synced"
+  },
+  "screen.sync.main.localDeviceDescription": {
+    "message": "These devices are on your project and on the same wifi network as you."
+  },
+  "screen.sync.main.localDevices": {
+    "message": "Local Devices"
+  },
+  "screen.sync.main.sync": {
+    "message": "Sync"
+  }
+}

--- a/messages/copy.json
+++ b/messages/copy.json
@@ -1,25 +1,4 @@
 {
-  "Components.DeviceInfoContents.downloading": {
-    "message": "Downloading"
-  },
-  "Components.DeviceInfoContents.downloads": {
-    "message": "Downloads"
-  },
-  "Components.DeviceInfoContents.media": {
-    "message": "media"
-  },
-  "Components.DeviceInfoContents.observations": {
-    "message": "observations"
-  },
-  "Components.DeviceInfoContents.syncing": {
-    "message": "Syncing"
-  },
-  "Components.DeviceInfoContents.uploading": {
-    "message": "Uploading"
-  },
-  "Components.DeviceInfoContents.uploads": {
-    "message": "Uploads"
-  },
   "app.firstMessage": {
     "description": "Used as a tester",
     "message": "This is a test"

--- a/messages/copy.json
+++ b/messages/copy.json
@@ -1,8 +1,4 @@
 {
-  "app.firstMessage": {
-    "description": "Used as a tester",
-    "message": "This is a test"
-  },
   "screen.Home.coordinatorButtonText": {
     "message": "Sync (as Coordinator)"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "prepare": "husky install",
-    "extract-messages": "formatjs extract 'src/**/*.{ts,tsx}' --format crowdin --out-file ./messages/en.json",
+    "extract-messages": "formatjs extract 'src/**/*.{ts,tsx}' --format crowdin --out-file ./messages/copy.json",
     "build:translations": "node ./scripts/compile.js "
   },
   "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import "react-native-gesture-handler";
 
 import * as React from "react";
 import { registerRootComponent } from "expo";
-import { defineMessages } from "react-intl";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 
 import { IntlProvider } from "./contexts/IntlContext";
@@ -10,14 +9,6 @@ import { PermissionsProvider } from "./contexts/PermissionsContext";
 import { NavigationContainer } from "./navigation/NavigationContainer";
 import { SyncProvider } from "./contexts/SyncContext";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
-
-const m = defineMessages({
-  firstMessage: {
-    id: "app.firstMessage",
-    defaultMessage: "This is a test",
-    description: "Used as a tester",
-  },
-});
 
 export default function App() {
   return (

--- a/src/contexts/IntlContext.tsx
+++ b/src/contexts/IntlContext.tsx
@@ -49,12 +49,12 @@ type IntlSetContextType = Readonly<
   [string, Dispatch<SetStateAction<TranslatedLocales>>]
 >;
 
-const IntlSetContext = createContext<IntlSetContextType>(["en", () => {}]);
+const IntlSetContext = createContext<IntlSetContextType>(["copy", () => {}]);
 
 export const IntlProvider = ({ children }: { children: ReactNode }) => {
-  const [appLocale, setAppLocale] = useState<TranslatedLocales>("en");
+  const [appLocale, setAppLocale] = useState<TranslatedLocales>("copy");
 
-  const locale = appLocale || getSupportedLocale(appLocale) || "en";
+  const locale = appLocale || getSupportedLocale(appLocale) || "copy";
 
   const languageCode = locale.split("-")[0];
 

--- a/src/languages.json
+++ b/src/languages.json
@@ -99,6 +99,10 @@
     "nativeName": "Čeština",
     "englishName": "Czech"
   },
+  "copy": {
+    "nativeName": "copy",
+    "englishName": "copy"
+  },
   "cs-CZ": {
     "nativeName": "Čeština",
     "englishName": "Czech"


### PR DESCRIPTION
# Creates a copy file for copy deck purposes

Replaces `en.json` with `copy.json`. English copy can be edited directly in crowdin. 

## Proposed workflow
1. copy.json uploaded to crowdin via the `format.js` cli (done during automated pre-commit step)
2. Screen shots are uploaded to crowdin and [text is tagged](https://support.crowdin.com/adding-screenshots/)
3. New copy is added, creating an `en.json` file in the repo via the crowdin-github integration
4. When copy is complete, we change the configuration in order for the en.json to be the main file which all translations are based off of.